### PR TITLE
Add joystick support

### DIFF
--- a/src/embed/init.lua
+++ b/src/embed/init.lua
@@ -70,6 +70,22 @@ local eventHandlers = {
     call(juno.mouse._onEvent, e)
     call(juno.onMouseUp, e.x, e.y, e.button)
     end,
+  --TODO: Make e.joystick an actual joystick.
+  joyaxismotion = function(e)
+    call(juno.onJoyAxisMotion, e.joystick, e.axis, e.button)
+    end,
+  joyballmotion = function(e)
+    call(juno.onJoyBallMotion, e.joystick, e.ball, e.x, e.y)
+    end,
+  joybuttondown = function(e)
+    call(juno.onJoyButtonDown, e.joystick, e.button)
+    end,
+  joybuttonup = function(e)
+    call(juno.onJoyButtonUp, e.joystick, e.button)
+    end,
+  joyhatmotion = function(e)
+    call(juno.onJoyHatMotion, e.joystick, e.hat, e.state)
+    end,
   quit = function(e)
     call(juno.onQuit)
     os.exit()
@@ -127,7 +143,7 @@ end
 function juno.onError(msg, stacktrace)
   -- Create and print error string
   local tab = "    "
-  local str = 
+  local str =
     msg:gsub("\t", tab):gsub("\n+$", "") .. "\n\n" ..
     stacktrace:gsub("\t", tab)
   print("Error:\n" .. str)
@@ -142,13 +158,13 @@ function juno.onError(msg, stacktrace)
 
   --  Init error state
   local font, bigfont
-  local done = false 
+  local done = false
   local alpha = 0
 
   function juno.onUpdate()
     -- The initialisation of the error state's graphics is defered to the
     -- first onUpdate() call in case the error occurs in the audio thread in
-    -- which case it won't be able to change the openGL state 
+    -- which case it won't be able to change the openGL state
     juno.graphics.reset()
     juno.graphics.setClearColor(.15, .16, .2)
     font = juno.Font.fromEmbedded(14)
@@ -164,7 +180,7 @@ function juno.onError(msg, stacktrace)
   end
 
   function juno.onAudio() end
-   
+
   function juno.onDraw()
     juno.graphics.setAlpha(alpha)
     juno.graphics.drawText(bigfont, "Error", 40, 40)
@@ -220,7 +236,7 @@ package.path = package.path .. ";?/init.lua"
 
 
 -------------------------------------------------------------------------------
--- Init config    
+-- Init config
 -------------------------------------------------------------------------------
 
 local c = {}
@@ -256,7 +272,7 @@ juno.fs.mount(path)
 
 
 -------------------------------------------------------------------------------
--- Init modules   
+-- Init modules
 -------------------------------------------------------------------------------
 
 juno.graphics.init(config.width, config.height, config.title,
@@ -264,10 +280,11 @@ juno.graphics.init(config.width, config.height, config.title,
 juno.graphics.setMaxFps(config.maxfps)
 juno.graphics.setClearColor(0, 0, 0)
 juno.audio.init(config.samplerate, config.buffersize)
+juno.joystick.init()
 
 
 -------------------------------------------------------------------------------
--- Init project   
+-- Init project
 -------------------------------------------------------------------------------
 
 if juno.fs.exists("main.lua") then
@@ -283,14 +300,14 @@ else
 
   function juno.onLoad()
     juno.graphics.setClearColor(0.15, 0.15, 0.15)
-    for i = 1, 30 do 
+    for i = 1, 30 do
       local p = {
         x = 0,
         y = (i / 30) * 100,
         z = 0,
         r = (i / 30) * 2,
       }
-      table.insert(particles, p) 
+      table.insert(particles, p)
     end
   end
 
@@ -338,4 +355,3 @@ else
 end
 
 xpcall(function() call(juno.onLoad) end, onError)
-

--- a/src/embed/init.lua
+++ b/src/embed/init.lua
@@ -72,19 +72,19 @@ local eventHandlers = {
     end,
   --TODO: Make e.joystick an actual joystick.
   joyaxismotion = function(e)
-    call(juno.onJoyAxisMotion, e.joystick, e.axis, e.button)
+    call(juno.onJoyAxisMotion, juno.joystick.joysticks[e.joystick+1], e.axis, e.button)
     end,
   joyballmotion = function(e)
-    call(juno.onJoyBallMotion, e.joystick, e.ball, e.x, e.y)
+    call(juno.onJoyBallMotion, juno.joystick.joysticks[e.joystick+1], e.ball, e.x, e.y)
     end,
   joybuttondown = function(e)
-    call(juno.onJoyButtonDown, e.joystick, e.button)
+    call(juno.onJoyButtonDown, juno.joystick.joysticks[e.joystick+1], e.button)
     end,
   joybuttonup = function(e)
-    call(juno.onJoyButtonUp, e.joystick, e.button)
+    call(juno.onJoyButtonUp, juno.joystick.joysticks[e.joystick+1], e.button)
     end,
   joyhatmotion = function(e)
-    call(juno.onJoyHatMotion, e.joystick, e.hat, e.state)
+    call(juno.onJoyHatMotion, juno.joystick.joysticks[e.joystick+1], e.hat, e.state)
     end,
   quit = function(e)
     call(juno.onQuit)
@@ -281,6 +281,12 @@ juno.graphics.setMaxFps(config.maxfps)
 juno.graphics.setClearColor(0, 0, 0)
 juno.audio.init(config.samplerate, config.buffersize)
 juno.joystick.init()
+
+--Open all of our joysticks and store them.
+juno.joystick.joysticks = {}
+for i=0,juno.joystick.getCount()-1 do
+  table.insert(juno.joystick.joysticks,juno.joystick.open(i))
+end
 
 
 -------------------------------------------------------------------------------

--- a/src/m_joystick.c
+++ b/src/m_joystick.c
@@ -6,6 +6,7 @@
  */
 
 
+#include <stdint.h>
 #include <SDL/SDL.h>
 #include "luax.h"
 #include "m_joystick.h"
@@ -59,7 +60,9 @@ static int l_joystick_getButtonCount(lua_State *L) {
 static int l_joystick_getAxis(lua_State *L) {
   Joystick *self = luaL_checkudata(L, 1, CLASS_NAME);
   int idx = luaL_checknumber(L, 2);
-  lua_pushnumber(L, SDL_JoystickGetAxis(self->joystick,idx));
+  /* Ugly normalization from int16 to double -1-1 */
+  int value = SDL_JoystickGetAxis(self->joystick,idx);
+  lua_pushnumber(L, ((double)value+0.5f)/(INT16_MAX+0.5f));
   return 1;
 }
 

--- a/src/m_joystick.c
+++ b/src/m_joystick.c
@@ -117,9 +117,15 @@ static int l_joystick_getName(lua_State *L) {
 
 static int l_joystick_open(lua_State *L) {
   int idx = luaL_checknumber(L, 1);
-  Joystick *self = joystick_new(L);
+  Joystick *self;
+
+  if (idx < 0 || idx >= SDL_NumJoysticks()) { /* Try to avoid the SDL error */
+    luaL_error(L, "Invalid joystick id: %d", idx);
+  }
+  self = joystick_new(L);
   self->joystick = SDL_JoystickOpen(idx);
-  if (self->joystick == NULL) {
+
+  if (self->joystick == NULL) { /* Oh well, we error anyways */
     luaL_error(L, "Could not open game controller. Error: %s", SDL_GetError());
     return 0;
   }

--- a/src/m_joystick.c
+++ b/src/m_joystick.c
@@ -90,7 +90,7 @@ static int l_joystick_getHat(lua_State *L) {
 static int l_joystick_getButton(lua_State *L) {
   Joystick *self = luaL_checkudata(L, 1, CLASS_NAME);
   int idx = luaL_checknumber(L, 2);
-  lua_pushnumber(L, SDL_JoystickGetButton(self->joystick,idx));
+  lua_pushboolean(L, SDL_JoystickGetButton(self->joystick,idx));
   return 1;
 }
 

--- a/src/m_joystick.c
+++ b/src/m_joystick.c
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2015 rxi
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT license. See LICENSE for details.
+ */
+
+
+#include <SDL/SDL.h>
+#include "luax.h"
+#include "m_joystick.h"
+#include "util.h"
+
+#define CLASS_NAME JOYSTICK_CLASS_NAME
+
+Joystick *joystick_new(lua_State *L) {
+  Joystick *self = lua_newuserdata(L, sizeof(*self));
+  luaL_setmetatable(L, CLASS_NAME);
+  memset(self, 0, sizeof(*self));
+  return self;
+}
+
+static int l_joystick_gc(lua_State *L) {
+  Joystick *self = luaL_checkudata(L, 1, CLASS_NAME);
+  SDL_JoystickClose(self->joystick);
+  return 0;
+}
+
+static int l_joystick_index(lua_State *L) {
+  Joystick *self = luaL_checkudata(L, 1, CLASS_NAME);
+  lua_pushnumber(L, SDL_JoystickIndex(self->joystick));
+  return 1;
+}
+
+static int l_joystick_getAxisCount(lua_State *L) {
+  Joystick *self = luaL_checkudata(L, 1, CLASS_NAME);
+  lua_pushnumber(L, SDL_JoystickNumAxes(self->joystick));
+  return 1;
+}
+
+static int l_joystick_getBallCount(lua_State *L) {
+  Joystick *self = luaL_checkudata(L, 1, CLASS_NAME);
+  lua_pushnumber(L, SDL_JoystickNumBalls(self->joystick));
+  return 1;
+}
+
+static int l_joystick_getHatCount(lua_State *L) {
+  Joystick *self = luaL_checkudata(L, 1, CLASS_NAME);
+  lua_pushnumber(L, SDL_JoystickNumHats(self->joystick));
+  return 1;
+}
+
+static int l_joystick_getButtonCount(lua_State *L) {
+  Joystick *self = luaL_checkudata(L, 1, CLASS_NAME);
+  lua_pushnumber(L, SDL_JoystickNumButtons(self->joystick));
+  return 1;
+}
+
+static int l_joystick_getAxis(lua_State *L) {
+  Joystick *self = luaL_checkudata(L, 1, CLASS_NAME);
+  int idx = luaL_checknumber(L, 2);
+  lua_pushnumber(L, SDL_JoystickGetAxis(self->joystick,idx));
+  return 1;
+}
+
+static int l_joystick_getBall(lua_State *L) {
+  int dx,dy;
+  Joystick *self = luaL_checkudata(L, 1, CLASS_NAME);
+  int idx = luaL_checknumber(L, 2);
+  SDL_JoystickGetBall(self->joystick,idx,&dx,&dy);
+  lua_pushnumber(L, dx);
+  lua_pushnumber(L, dy);
+  return 2;
+}
+
+static int l_joystick_getHat(lua_State *L) {
+  Joystick *self = luaL_checkudata(L, 1, CLASS_NAME);
+  int idx = luaL_checknumber(L, 2);
+  int value = SDL_JoystickGetHat(self->joystick,idx);
+
+  lua_newtable(L);
+  luax_setfield_bool(L, "up", value & SDL_HAT_UP);
+  luax_setfield_bool(L, "down", value & SDL_HAT_DOWN);
+  luax_setfield_bool(L, "left", value & SDL_HAT_LEFT);
+  luax_setfield_bool(L, "right", value & SDL_HAT_RIGHT);
+
+  return 1;
+}
+
+static int l_joystick_getButton(lua_State *L) {
+  Joystick *self = luaL_checkudata(L, 1, CLASS_NAME);
+  int idx = luaL_checknumber(L, 2);
+  lua_pushnumber(L, SDL_JoystickGetButton(self->joystick,idx));
+  return 1;
+}
+
+static int l_joystick_init(lua_State *L) {
+  if (SDL_Init(SDL_INIT_JOYSTICK) != 0) {
+    luaL_error(L, "could not init joystick");
+  }
+  /* Make SDL push events through the event system */
+  SDL_JoystickEventState(SDL_ENABLE);
+  return 0;
+}
+
+static int l_joystick_getCount(lua_State *L) {
+  lua_pushnumber(L, SDL_NumJoysticks());
+  return 1;
+}
+
+
+static int l_joystick_getName(lua_State *L) {
+  int idx = luaL_checknumber(L, 1);
+  lua_pushstring(L, SDL_JoystickName(idx));
+  return 1;
+}
+
+static int l_joystick_open(lua_State *L) {
+  int idx = luaL_checknumber(L, 1);
+  Joystick *self = joystick_new(L);
+  self->joystick = SDL_JoystickOpen(idx);
+  if (self->joystick == NULL) {
+    luaL_error(L, "Could not open game controller. Error: %s", SDL_GetError());
+    return 0;
+  }
+  return 1;
+}
+
+int luaopen_joystick(lua_State *L) {
+  /* Used for the Joystick object. */
+  luaL_Reg reg[] = {
+    { "__gc",            l_joystick_gc              },
+    { "index",           l_joystick_index           },
+    { "getAxisCount",    l_joystick_getAxisCount    },
+    { "getBallCount",   l_joystick_getBallCount   },
+    { "getHatCount",    l_joystick_getHatCount    },
+    { "getButtonCount", l_joystick_getButtonCount },
+    { "getAxis",         l_joystick_getAxis         },
+    { "getBall",         l_joystick_getBall         },
+    { "getHat",          l_joystick_getHat          },
+    { "getButton",       l_joystick_getButton       },
+    { NULL, NULL }
+  };
+  ASSERT( luaL_newmetatable(L, CLASS_NAME) );
+  luaL_setfuncs(L, reg, 0);
+  lua_pushvalue(L, -1);
+  lua_setfield(L, -2, "__index");
+  return 1;
+}
+
+int luaopen_joystick_functions(lua_State *L) {
+  /* Used for the joystick module. */
+  luaL_Reg reg[] = {
+    { "init",         l_joystick_init        },
+    { "open",         l_joystick_open        },
+    { "getCount",     l_joystick_getCount    },
+    { "getName",      l_joystick_getName     },
+    { NULL, NULL }
+  };
+  luaL_newlib(L, reg);
+  return 1;
+}

--- a/src/m_joystick.h
+++ b/src/m_joystick.h
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2015 rxi
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT license. See LICENSE for details.
+ */
+
+
+#ifndef JOYSTICK_H
+#define JOYSTICK_H
+
+#include <SDL/SDL.h>
+
+#define JOYSTICK_CLASS_NAME "Joystick"
+
+typedef struct {
+  SDL_Joystick *joystick;
+} Joystick;
+
+#endif

--- a/src/m_juno.c
+++ b/src/m_juno.c
@@ -1,4 +1,4 @@
-/** 
+/**
  * Copyright (c) 2015 rxi
  *
  * This library is free software; you can redistribute it and/or modify it
@@ -30,6 +30,9 @@ int luaopen_font(lua_State *L);
 int luaopen_source(lua_State *L);
 int luaopen_data(lua_State *L);
 
+int luaopen_joystick(lua_State *L);
+int luaopen_joystick_functions(lua_State *L);
+
 int luaopen_juno(lua_State *L) {
   luaL_Reg reg[] = {
     { "getVersion",  l_juno_getVersion  },
@@ -45,14 +48,16 @@ int luaopen_juno(lua_State *L) {
     { "Buffer",   luaopen_buffer    },
     { "Source",   luaopen_source    },
     { "Data",     luaopen_data      },
+    { "Joystick", luaopen_joystick  },
     /* Modules */
-    { "system",   luaopen_system    },
-    { "fs",       luaopen_fs        },
-    { "time",     luaopen_time      },
-    { "graphics", luaopen_graphics  },
-    { "audio",    luaopen_audio     },
-    { "mouse",    luaopen_mouse     },
-    { "bufferfx", luaopen_bufferfx  },
+    { "joystick", luaopen_joystick_functions  },
+    { "system",   luaopen_system              },
+    { "fs",       luaopen_fs                  },
+    { "time",     luaopen_time                },
+    { "graphics", luaopen_graphics            },
+    { "audio",    luaopen_audio               },
+    { "mouse",    luaopen_mouse               },
+    { "bufferfx", luaopen_bufferfx            },
     { NULL, NULL },
   };
   for (i = 0; mods[i].name; i++) {

--- a/src/m_system.c
+++ b/src/m_system.c
@@ -1,4 +1,4 @@
-/** 
+/**
  * Copyright (c) 2015 rxi
  *
  * This library is free software; you can redistribute it and/or modify it
@@ -97,6 +97,46 @@ static int l_system_poll(lua_State *L) {
         luax_setfield_number(L, "x", e.button.x);
         luax_setfield_number(L, "y", e.button.y);
         break;
+
+      case SDL_JOYAXISMOTION:
+        luax_setfield_string(L, "type", "joyaxismotion");
+        luax_setfield_number(L, "joystick", e.jaxis.which);
+        luax_setfield_number(L, "axis", e.jaxis.axis);
+        luax_setfield_number(L, "value", e.jaxis.value);
+        break;
+
+      case SDL_JOYBALLMOTION:
+        luax_setfield_string(L, "type", "joyballmotion");
+        luax_setfield_number(L, "joystick", e.jball.which);
+        luax_setfield_number(L, "ball", e.jball.ball);
+        luax_setfield_number(L, "x", e.jball.xrel);
+        luax_setfield_number(L, "y", e.jball.yrel);
+        break;
+
+      case SDL_JOYBUTTONDOWN:
+        luax_setfield_string(L, "type", "joybuttondown");
+        luax_setfield_number(L, "joystick", e.jbutton.which);
+        luax_setfield_number(L, "button", e.jbutton.button);
+        break;
+
+      case SDL_JOYBUTTONUP:
+        luax_setfield_string(L, "type", "joybuttonup");
+        luax_setfield_number(L, "joystick", e.jbutton.which);
+        luax_setfield_number(L, "button", e.jbutton.button);
+        break;
+
+      case SDL_JOYHATMOTION:
+        luax_setfield_string(L, "type", "joyhatmotion");
+        luax_setfield_number(L, "joystick", e.jhat.which);
+        luax_setfield_number(L, "hat", e.jhat.hat);
+
+        lua_newtable(L); /* e.state */
+        luax_setfield_bool(L, "up", e.jhat.value & SDL_HAT_UP);
+        luax_setfield_bool(L, "down", e.jhat.value & SDL_HAT_DOWN);
+        luax_setfield_bool(L, "left", e.jhat.value & SDL_HAT_LEFT);
+        luax_setfield_bool(L, "right", e.jhat.value & SDL_HAT_RIGHT);
+        lua_setfield(L, -2, "state"); /* push state to event table */
+        break;
     }
 
     /* Push event to events table */
@@ -123,9 +163,9 @@ static int l_system_info(lua_State *L) {
   if (!strcmp(str, "os")) {
 #if _WIN32
     lua_pushstring(L, "windows");
-#elif __linux__ 
+#elif __linux__
     lua_pushstring(L, "linux");
-#elif __FreeBSD__ 
+#elif __FreeBSD__
     lua_pushstring(L, "bsd");
 #elif __APPLE__
     lua_pushstring(L, "osx");

--- a/src/m_system.c
+++ b/src/m_system.c
@@ -6,9 +6,11 @@
  */
 
 
+#include <stdint.h>
 #include <SDL/SDL.h>
 #include "util.h"
 #include "luax.h"
+
 
 #if _WIN32
   #include <windows.h>
@@ -102,7 +104,8 @@ static int l_system_poll(lua_State *L) {
         luax_setfield_string(L, "type", "joyaxismotion");
         luax_setfield_number(L, "joystick", e.jaxis.which);
         luax_setfield_number(L, "axis", e.jaxis.axis);
-        luax_setfield_number(L, "value", e.jaxis.value);
+        int value = e.jaxis.value;
+        luax_setfield_number(L, "value", ((double)value+0.5f)/(INT16_MAX+0.5f));
         break;
 
       case SDL_JOYBALLMOTION:

--- a/tests/joystick/main.lua
+++ b/tests/joystick/main.lua
@@ -1,0 +1,39 @@
+-- if love then
+--   function love.load()
+--     joystick = nil
+--   end
+--
+--
+--   function love.update(dt)
+--     if love.joystick.getJoystickCount() >= 1 and joystick == nil then
+--       joystick = love.joystick.getJoysticks( )[1]
+--       print(string.format("Opening joystick with name %s reported id is %d %d",joystick:getName(),joystick:getID()))
+--     end
+--   end
+--
+--
+--   function love.joystickhat(...)
+--     print(...)
+--   end
+-- end
+function juno.onLoad()
+  for _,joystick in ipairs(juno.joystick.joysticks) do
+    print(string.format("Joystick with name '%s' reported id is %d",juno.joystick.getName(joystick:index()),joystick:index()))
+    print(string.format("  Axes count: %d",joystick:getAxisCount()))
+    print(string.format("  Hat count: %d",joystick:getHatCount()))
+    print(string.format("  Ball count: %d",joystick:getBallCount()))
+    print(string.format("  Button count: %d",joystick:getButtonCount()))
+  end
+  juno.joystick.open(22)
+end
+
+function juno.onDraw()
+  -- sdf
+end
+
+function juno.onJoyHatMotion(joystick,hat,state)
+  print("Hat Motion:",joystick:index(),hat)
+  for d,v in pairs(state) do
+    print("  ",d,v)
+  end
+end


### PR DESCRIPTION
Adds basic joystick support. Unfortunately the user has to track the
joysticks as the event callbacks give the joystick index. Currently I'm
mulling over the best way to do this.

If you don't want to merge yet tell me why and I'll make fixes. Because you are using SDL1 I don't have access to gamepad mapping APIs from SDL2.
